### PR TITLE
Add tests for deep validation and fix isValid() signature inconsistency

### DIFF
--- a/backbone-schema.js
+++ b/backbone-schema.js
@@ -1161,7 +1161,7 @@
                     // Only validate relations when options.deep is specified
                     if(options.deep === true) {
 
-                        if(isModel && !value.isValid(undefined, options)) {
+                        if(isModel && !value.isValid(options)) {
                             errors.push({
                                 level: 'error',
                                 rule: 'relation',
@@ -1462,7 +1462,7 @@
             var errors = [];
 
             if(_.any(this.models, function(model) {
-                return !model.isValid(undefined, options);
+                return !model.isValid(options);
             })) {
                 errors.push({
                     level: 'error',

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "underscore": ">=1.4.2"
   },
   "devDependencies": {
-    "mocha": "1.6.0",
-    "chai": "1.4.0",
-    "sinon": "1.5.2"
+    "mocha": ">=1.6.0",
+    "chai": ">=1.4.0",
+    "sinon": ">=1.5.2"
   },
   "scripts": {
       "test": "./node_modules/.bin/mocha --recursive --reporter spec --ui bdd test/*.js"

--- a/test/backbone-schema-tests.js
+++ b/test/backbone-schema-tests.js
@@ -1724,6 +1724,38 @@
                         assert.isTrue(tester.testModelErrors("a2c"));
                     });
                 });
+
+                describe('deep', function() {
+
+                    var model;
+                    beforeEach(function() {
+                        model = SchemaFactory.createInstance({
+                            'type' : 'object',
+                            'properties' : {
+                                'nested'  : {
+                                    'type' : 'object',
+                                    'properties' : {
+                                        'id' : {
+                                            'type' : 'number'
+                                        }
+                                    }
+                                }
+                            }
+                        }, {
+                            nested : {
+                                id : 'string'
+                            }
+                        });
+                    });
+
+                    it('should validate when `deep` option is not set', function() {
+                        assert.isTrue(model.isValid());
+                    });
+
+                    it('should not validate when `deep` option is set', function() {
+                        assert.isFalse(model.isValid({deep:true}));
+                    });
+                });
             });
         });
 
@@ -2040,7 +2072,7 @@
 
                     it('should not validate when minItems constraint is not met', function() {
                         var collection = tester.model.get('minItems');
-                        collection.add(1);
+                        collection.add([1]);
                         assert.isFalse(tester.isValid(undefined, {
                             deep: true
                         }));
@@ -2048,7 +2080,7 @@
 
                     it('should return appropriate errors when minItems constraint is not met', function() {
                         var collection = tester.model.get('minItems');
-                        collection.add(1);
+                        collection.add([1]);
                         assert.isTrue(tester.testCollectionErrors(undefined, {
                             deep: true
                         }));


### PR DESCRIPTION
Deep models weren't validated properly due to inconsistent isValid() calls.
