### PR TITLE
Removed incorrect handling ```toJSON()``` for empty collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+.idea

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+NOTE
+====
+This is a patched and npm-published version of https://github.com/redpie/backbone-schema
+
 Backbone.Schema
 ===============
 

--- a/backbone-schema.js
+++ b/backbone-schema.js
@@ -1501,10 +1501,6 @@
             var toReturn;
             if(this.schema) {
                 var models = this.models;
-                if(models.length === 0) {
-                    return undefined;
-                }
-
                 toReturn = [];
                 _.each(models, function(model) {
                     var value = model.toJSON(options);

--- a/backbone-schema.js
+++ b/backbone-schema.js
@@ -887,7 +887,7 @@
             if(this.schema) {
                 _.each(this.schema.properties, function(property, name) {
                     var attribute = this.attributes[name];
-                    if(attribute) {
+                    if ([undefined, null].indexOf(attribute) === -1) {
                         var value;
                         if(this.schemaRelations[name]) {
                             value = attribute.toJSON(options);

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
-  "name"          : "backbone-schema",
-  "description"   : "Create Backbone models and collections from JSON Schema",
+  "name"          : "backbone-json-schema",
+  "description"   : "A patched and npm published fork of https://github.com/redpie/backbone-schema --- Create Backbone models and collections from JSON Schema",
   "keywords"      : ["Backbone", "schema", "json", "jsonschema", "nested", "model", "collection"],
-  "repository"    : "git://github.com/redpie/backbone-schema.git",
-  "author"        : "Redpie",
+  "repository"    : "git://github.com/Reggino/backbone-json-schema.git",
   "contributors"  : "Listed at <https://github.com/redpie/backbone-schema/graphs/contributors>",
   "dependencies"  : {
     "backbone":   ">=0.9.2",


### PR DESCRIPTION
Hi,

This is awesome stuff, thanks! I did notice however some weird behavior when serializing empty collections. 

In that case, the result value is `undefined` where i expected `[]`. Besides, `toJSONInProgress` (set to `true` on line 1499) is not being set to false, making future calls to `toJSON()` impossible. This should fix that.
