### PR TITLE
hotfix: boolean 'false' value is missing on toJSON

### DIFF
--- a/backbone-schema.js
+++ b/backbone-schema.js
@@ -887,7 +887,7 @@
             if(this.schema) {
                 _.each(this.schema.properties, function(property, name) {
                     var attribute = this.attributes[name];
-                    if(attribute) {
+                    if(attribute !== void 0) {
                         var value;
                         if(this.schemaRelations[name]) {
                             value = attribute.toJSON(options);


### PR DESCRIPTION
If the attribute value is boolean and false, the existing condition will ignore and value is missing on toJSON.
